### PR TITLE
Feature/registration remove

### DIFF
--- a/src/api/custom_middleware.py
+++ b/src/api/custom_middleware.py
@@ -1,0 +1,24 @@
+from django.http import HttpResponseForbidden
+
+
+class PreventRegistrationMiddleware:
+    """
+    Middleware for preventing user registration access.
+
+    This middleware class restricts access to
+    user registration pages by checking
+    the request's path. If the path starts with '/auth/register/',
+    it returns an HTTP 403 Forbidden response
+    with a message indicating that registration
+    is not allowed.
+    """
+
+    def __init__(self, get_response):
+        """Initialize the PreventRegistrationMiddleware."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """Check for registration access and handle the request."""
+        if request.path.startswith('/auth/register/'):
+            return HttpResponseForbidden("Registration is not allowed")
+        return self.get_response(request)

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
@@ -40,4 +40,10 @@ urlpatterns = [
     path('', include(router.urls)),
     path('', include('djoser.urls')),
     path('auth/', include('djoser.urls.authtoken')),
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$',
+            schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('swagger/', schema_view.with_ui('swagger',
+         cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc',
+         cache_timeout=0), name='schema-redoc'),
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -41,6 +41,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'api.custom_middleware.PreventRegistrationMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'


### PR DESCRIPTION
В urls пропали пути для swagger и redoc - это случайно или так нужно? Пока снова добавила.

Самый легкий вариант убрать регистрацию - создать кастомное middleware. Там указывается путь, по которому будет пытаться проходить пользователь для регистрации и который будет закрыт. Путь я пока указала тестовый. Так всё работает.